### PR TITLE
Build updates to support newer waf/Python 3, also maybe fixed the error shown in issue 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,19 @@ This code is completely based on original https://sourceforge.net/projects/geepr
 
 I wanted some EPROM programmer software which would work on GNU/Linux and I found the above repo that seemed quite abandoned. Wine was not an option.
 
-Following its README instructions I got an error in the first `waf configure` step:
+11/2025: The build process has been updated so that it runs (at least for me) on newer systems with Python3 and a current version of *maf*, so the old notes about using Python2 are now irrelevant.
 
-```
-ValueError: invalid mode: 'rU'
-```
-
-I was using python 3.11 but running `waf` with python 2.7 solved the issue.
-
-After that one I got a linker related error:
-
+Everything might just build smoothly just by running:
 
 ```bash
-[101/101] cxxprogram: build_directory/src/buffer.cpp.1.o build_directory/src/chip.cpp.1.o build_directory/src/dummy.cpp.1.o build_directory/src/storings.cpp.1.o build_directory/src/iface.cpp.1.o build_directory/src/files.cpp.1.o build_directory/src/parport.cpp.1.o build_directory/src/timer.cpp.1.o build_directory/src/protocols.cpp.1.o build_directory/src/script.cpp.1.o build_directory/src/checksum.cpp.1.o build_directory/src/cfp.c.1.o build_directory/src/main.cpp.2.o -> build_directory/geepro
-/usr/bin/ld: /home/enrique/Proyectos/geepro_0.0.4/geepro/build_directory/gui-gtk/libgui-gtk.a(bineditor.c.1.o):(.bss+0x0): multiple definition of `GuiBineditorColorsSet'; /home/enrique/Proyectos/geepro_0.0.4/geepro/build_directory/gui-gtk/libgui-gtk.a(gui.c.1.o):(.bss+0x0): first defined here
-```
-
-Could fix it changing the definition of `GuiBineditorColorsSet` at ```gui-gtk/bineditor.h``` as `typedef enum` instead of just `enum`.
-
-After that everything built smoothly just by running :
-
-```bash
-python2 waf configure --prefix=/usr/local
-python2 waf build
-python2 waf install
+waf configure --prefix=/usr/local
+waf build
+waf install
 ```
 
 Then ```geepro``` executable is available at ```/usr/local/bin```.
 
 Hope it is useful for anyone looking for writing EPROMs.
 
-** Tried to make it work with a USB SP200S board but it does not work.
+** Upon review, this code appears to only support a stack of parallel port programmers for the moment.  If you have one of those, it may work for you. **
+

--- a/drivers/wscript
+++ b/drivers/wscript
@@ -2,10 +2,10 @@
 # drivers
 def build(bld):
   print('→ building drivers')
-  drivers_base=["jtag_noname","willem","stk200","galblast","altera_byteblaster","xilinx_cable_iii","altera_byteblaster","funprog"]
+  drivers_base=["jtag_noname","willem","stk200","galblast","altera_byteblaster","xilinx_cable_iii","funprog"]
 
   for driver in drivers_base:
-    b=bld(
+    b=bld.shlib(
       features = 'cxx cxxshlib',
       source = driver+'.cpp',
       target=driver,

--- a/gui-gtk/gui.h
+++ b/gui-gtk/gui.h
@@ -168,7 +168,7 @@ struct _sqw_gen
 #define ADD_PIN_L(nm,id, act)	gui_add_pin(gep, tmp, nm, 0, 1.3, id, gui_test_pin##act)    
 #define SET_HW_ADDR(adr)	g_print("Set addr: %i\n",adr);
 #define SET_HW_DATA(data)	g_print("Set data: %i\n",data);
-#define gui_error_box(wg, msg, opt...)	gui_dialog_box(wg,"[ER][TEXT]"msg"[/TEXT][BR] OK ", ##opt)
+#define gui_error_box(wg, msg, opt...)	gui_dialog_box(wg,"[ER][TEXT]" msg "[/TEXT][BR] OK ", ##opt)
 
 #define FO_RB_FIRST	1
 #define FO_RB_NEXT	2

--- a/gui-gtk/wscript
+++ b/gui-gtk/wscript
@@ -7,7 +7,7 @@ def configure(conf):
 
 def build(bld):
   print('→ building gui')
-  bld(
+  bld.shlib(
   features = 'cxx cxxstlib',
   source  = ["bineditor.c","gui.c","gui_xml.c","be_panel.c", "be_buffer.c", "be_bitmap.c", "be_asmview.c", "be_stencil.c", "index_stc.c"],
   target  = 'gui-gtk',

--- a/wscript
+++ b/wscript
@@ -11,12 +11,12 @@ out = 'build_directory'
 
 def options(opt):
 	# command-line options provided by a waf tool
-	opt.tool_options('compiler_cxx')
+	opt.load('compiler_cxx')
 
 
 def configure(conf):
   print('→ configuring the project')
-  conf.check_tool('gcc g++ intltool')
+  conf.load('gcc g++ intltool')
   conf.env.CPPFLAGS  = ['-O2','-Wall']
   conf.env.CXXFLAGS  = ['-O2','-Wall','-fcommon']
   conf.recurse('gui-gtk')
@@ -63,8 +63,7 @@ def build(bld):
 
   bld(
     features     = 'cxx cprogram',
-    add_objects  = ['maincode',"main.o"],
-    use          = ['gui-gtk'],
+    use          = ['gui-gtk','maincode','main.o'],
     uselib       = ['GTK+-3.0','CAIRO','LIBXML-2.0','DL'],
     target       = bld.env.APPNAME,
   )


### PR DESCRIPTION
I redid some of the build process to get this going on RHEL 9.  Changes here allow us to use the current waf and the stock Python 3, at least on RHEL.  Doesn't seem likely they'll break other builds with any sufficiently recent waf.

Also took a stab at addressing the error in your issue 1, though I haven't built it with CLANG, myself, and it's possible that the one error mentioned in that issue isn't the only problem with a strict C++11 build.